### PR TITLE
Allow method access on non-structs

### DIFF
--- a/evaluationStage.go
+++ b/evaluationStage.go
@@ -325,14 +325,16 @@ func makeAccessorStage(pair []string) evaluationOperator {
 				coreValue = coreValue.Elem()
 			}
 
-			if coreValue.Kind() != reflect.Struct {
-				return nil, errors.New("Unable to access '" + pair[i] + "', '" + pair[i-1] + "' is not a struct")
+			if coreValue.Kind() == reflect.Struct {
+				field := coreValue.FieldByName(pair[i])
+				if field != (reflect.Value{}) {
+					value = field.Interface()
+					continue
+				}
 			}
 
-			field := coreValue.FieldByName(pair[i])
-			if field != (reflect.Value{}) {
-				value = field.Interface()
-				continue
+			if !coreValue.IsValid() {
+				return nil, errors.New("Unable to access '" + pair[i] + "', '" + pair[i-1] + "' is not valid")
 			}
 
 			method := coreValue.MethodByName(pair[i])


### PR DESCRIPTION
I was trying to do an expression with a uuid `.String()` method, but reflect shows that as an array instead of struct.

All of the tests pass and my use case seems to work now...so I think we're good?