### PR TITLE
Allow variables in EvalParams to be additional expressions

### DIFF
--- a/Eval.go
+++ b/Eval.go
@@ -17,16 +17,12 @@ func (expr ExprNode) Eval(params EvalParams) (interface{}, error) {
 			return nil, fmt.Errorf("variable undefined: %v [pos=%d; len=%d]", expr.Name, expr.SourcePos, expr.SourceLen)
 		}
 
-		val, stringType := value.(string)
-		if !stringType {
+		// Check if var is a node that can be Eval'd
+		node, nodeType := value.(ExprNode)
+		if !nodeType {
 			return value, nil
 		}
 
-		// Try to parse string in case var is an additional expression
-		node, err := Parse(val)
-		if err != nil {
-			return value, nil
-		}
 		for _, v := range node.Vars() {
 			if v == expr.Name {
 				return nil, fmt.Errorf("variable can not refer to itself: %v [pos=%d; len=%d]", expr.Name, expr.SourcePos, expr.SourceLen)

--- a/Parse.go
+++ b/Parse.go
@@ -31,6 +31,24 @@ func Parse(input string) (ExprNode, error) {
 	return expr, err
 }
 
+// MustParse returns an AST or panics if string cannot be parsed.
+func MustParse(input string) ExprNode {
+	expr, err := Parse(input)
+	if err != nil {
+		panic(fmt.Errorf("MustParse error: %v", err))
+	}
+	return expr
+}
+
+// TryParse returns an ExprNodeLiteral if the string cannot be parsed
+func TryParse(input string) ExprNode {
+	expr, err := Parse(input)
+	if err != nil {
+		return NewExprNodeLiteral(input, 0, len(input))
+	}
+	return expr
+}
+
 func parseExpr(s *TokenStream, minPrecedence int) (ExprNode, error) {
 	lhs, err := parseIndexer(s)
 	if err != nil {

--- a/Reduce.go
+++ b/Reduce.go
@@ -10,13 +10,38 @@ func (expr ExprNode) Reduce(params EvalParams, optimizers map[string]Optimizer) 
 		return expr, nil
 
 	case NodeTypeVariable:
-		if value, ok := params.Variables[expr.Name]; ok {
-			// variable is known, replace it with value literal
+		value, ok := params.Variables[expr.Name]
+		if !ok {
+			// variable is unknown, return as is
+			return expr, nil
+		}
+
+		val, stringType := value.(string)
+		if !stringType {
+			// variable is known and non-string, replace it with value literal
 			return NewExprNodeLiteral(value, expr.SourcePos, expr.SourceLen), nil
 		}
-		// variable is unknown, return as is
-		return expr, nil
 
+		// Try to parse string in case var is an additional expression
+		node, err := Parse(val)
+		if err != nil {
+			return NewExprNodeLiteral(value, expr.SourcePos, expr.SourceLen), nil
+		}
+		node.SourcePos = expr.SourcePos
+		node.SourceLen = expr.SourceLen
+
+		for _, v := range node.Vars() {
+			if v == expr.Name {
+				return ExprNode{}, fmt.Errorf("variable can not refer to itself: %v [pos=%d; len=%d]", expr.Name, expr.SourcePos, expr.SourceLen)
+			}
+		}
+
+		// Reduce the new node
+		reduced, err := node.Reduce(params, optimizers)
+		if err != nil {
+			return node, nil
+		}
+		return reduced, nil
 	case NodeTypeOperator:
 		// reduce arguments
 		reducedArgs := make([]ExprNode, len(expr.Args))

--- a/eval_test.go
+++ b/eval_test.go
@@ -79,12 +79,22 @@ func TestEval(t *testing.T) {
 		},
 		testCase{
 			"a == 9",
-			map[string]interface{}{"a": "(10-1)"},
+			map[string]interface{}{"a": MustParse("(10-1)")},
 			true,
 		},
 		testCase{
 			"a == 9",
-			map[string]interface{}{"a": "(b-1)", "b": "10"},
+			map[string]interface{}{"a": MustParse("(b-1)"), "b": 10.0},
+			true,
+		},
+		testCase{
+			"a == 'b'",
+			map[string]interface{}{"a": NewExprNodeLiteral("b", 0, 1)},
+			true,
+		},
+		testCase{
+			"a == '0x12g1'",
+			map[string]interface{}{"a": TryParse("0x12g1")},
 			true,
 		},
 	}

--- a/eval_test.go
+++ b/eval_test.go
@@ -77,6 +77,16 @@ func TestEval(t *testing.T) {
 			map[string]interface{}{"a": uint(9)},
 			true,
 		},
+		testCase{
+			"a == 9",
+			map[string]interface{}{"a": "(10-1)"},
+			true,
+		},
+		testCase{
+			"a == 9",
+			map[string]interface{}{"a": "(b-1)", "b": "10"},
+			true,
+		},
 	}
 	for _, testCase := range testCases {
 		expr, err := Parse(testCase.input)

--- a/reduce_test.go
+++ b/reduce_test.go
@@ -90,6 +90,30 @@ func TestReduce(test *testing.T) {
 	}, "z < -0.15 && z > -0.5")
 
 	runTest(test, "x ? (y > 0.15 && y < 0.5) : (z < -0.15 && z > -0.5)", map[string]interface{}{}, "x ? y > 0.15 && y < 0.5 : z < -0.15 && z > -0.5")
+
+	runTest(test, "x + y * z", map[string]interface{}{
+		"x": 1.0,
+		"y": "a",
+		"z": 3.0,
+	}, "1 + a * 3")
+
+	runTest(test, "x + y * z", map[string]interface{}{
+		"x": 1.0,
+		"y": "2",
+		"z": 3.0,
+	}, "7")
+
+	runTest(test, "x + y * z", map[string]interface{}{
+		"x": 1.0,
+		"y": "(1+1)",
+		"z": 3.0,
+	}, "7")
+
+	runTest(test, "x + y * z", map[string]interface{}{
+		"x": 1.0,
+		"y": "(1+1 - d + h)",
+		"z": 3.0,
+	}, "1 + (2 - d + h) * 3")
 }
 
 func runTest(test *testing.T, input string, parameters map[string]interface{}, expectedOutput string) {

--- a/reduce_test.go
+++ b/reduce_test.go
@@ -93,25 +93,19 @@ func TestReduce(test *testing.T) {
 
 	runTest(test, "x + y * z", map[string]interface{}{
 		"x": 1.0,
-		"y": "a",
+		"y": MustParse("a"),
 		"z": 3.0,
 	}, "1 + a * 3")
 
 	runTest(test, "x + y * z", map[string]interface{}{
 		"x": 1.0,
-		"y": "2",
+		"y": MustParse("(1+1)"),
 		"z": 3.0,
 	}, "7")
 
 	runTest(test, "x + y * z", map[string]interface{}{
 		"x": 1.0,
-		"y": "(1+1)",
-		"z": 3.0,
-	}, "7")
-
-	runTest(test, "x + y * z", map[string]interface{}{
-		"x": 1.0,
-		"y": "(1+1 - d + h)",
+		"y": MustParse("(1+1 - d + h)"),
 		"z": 3.0,
 	}, "1 + (2 - d + h) * 3")
 }


### PR DESCRIPTION
This allows variables in the params map to be additional expressions. Let me know if there's a better way to achieve the same result but this seems to be working.

The only small issue that I found is that Reduce doesn't reduce fully in certain cases where a variable contains an additional variable.
Example:
```
"x + y * z" 
map[string]interface{}{"d": 1.0, "x": 1.0, "y": "1+1 - d + h", "z": 3.0}
```

Ends up becoming
`"1 + (1 + h) * 3"`

Instead of
`"2 + h * 3"`